### PR TITLE
fix #48: use correct upper-cammel-case words

### DIFF
--- a/models/src/field_info.rs
+++ b/models/src/field_info.rs
@@ -4,7 +4,7 @@ use utils::BkdrHasher;
 
 use crate::{
     errors::{Error, Result},
-    FieldID, FieldName, SeriesID,
+    FieldId, FieldName, SeriesId,
 };
 
 const FIELD_NAME_MAX_LEN: usize = 512;
@@ -60,7 +60,7 @@ impl From<protos::models::FieldType> for ValueType {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct FieldInfo {
-    id: FieldID,
+    id: FieldId,
     name: FieldName,
     value_type: ValueType,
 
@@ -69,7 +69,7 @@ pub struct FieldInfo {
 }
 
 impl FieldInfo {
-    pub fn new(series_id: SeriesID, name: FieldName, value_type: ValueType) -> Self {
+    pub fn new(series_id: SeriesId, name: FieldName, value_type: ValueType) -> Self {
         let mut fi = FieldInfo { id: 0, name, value_type, finished: true };
         fi.finish(series_id);
         fi
@@ -92,12 +92,12 @@ impl FieldInfo {
         Ok(())
     }
 
-    pub fn finish(&mut self, series_id: SeriesID) {
+    pub fn finish(&mut self, series_id: SeriesId) {
         self.finished = true;
         self.id = generate_field_id(&self.name, series_id);
     }
 
-    pub fn field_id(&self) -> FieldID {
+    pub fn field_id(&self) -> FieldId {
         self.id
     }
 
@@ -110,14 +110,14 @@ impl FieldInfo {
     }
 }
 
-pub fn generate_field_id(name: &FieldName, sid: SeriesID) -> FieldID {
+pub fn generate_field_id(name: &FieldName, sid: SeriesId) -> FieldId {
     let mut hash = BkdrHasher::with_number(sid);
     hash.hash_with(name.as_slice());
     hash.number()
 }
 
-/// Split a 16 byte FieldID to 8 byte SeriesID and 8 byte FieldHash
-// pub fn split_field_id(fid: &FieldID) -> (SeriesID, FieldHash) {
+/// Split a 16 byte FieldId to 8 byte SeriesId and 8 byte FieldHash
+// pub fn split_field_id(fid: &FieldId) -> (SeriesId, FieldHash) {
 //     ((*fid >> 64 & u64::MAX as u128) as u64, (*fid & u64::MAX as u128) as u64)
 // }
 

--- a/models/src/lib.rs
+++ b/models/src/lib.rs
@@ -10,16 +10,16 @@ pub use points::*;
 pub use series_info::{generate_series_id, SeriesInfo};
 pub use tag::Tag;
 
-pub type ShardID = u64;
-pub type CatalogID = u64;
-pub type SchemaID = u64;
-pub type SeriesID = u64;
-pub type TableID = u64;
+pub type ShardId = u64;
+pub type CatalogId = u64;
+pub type SchemaId = u64;
+pub type SeriesId = u64;
+pub type TableId = u64;
 
 pub type TagKey = Vec<u8>;
 pub type TagValue = Vec<u8>;
 
-pub type FieldID = u64;
+pub type FieldId = u64;
 pub type FieldName = Vec<u8>;
 
 pub type Timestamp = i64;

--- a/models/src/points.rs
+++ b/models/src/points.rs
@@ -1,12 +1,12 @@
 use protos::models as fb_models;
 
 use crate::{
-    field_info, generate_series_id, Error, FieldID, Result, SeriesID, Tag, Timestamp, ValueType,
+    field_info, generate_series_id, Error, FieldId, Result, SeriesId, Tag, Timestamp, ValueType,
 };
 
 #[derive(Debug)]
 pub struct FieldValue {
-    pub field_id: FieldID,
+    pub field_id: FieldId,
     pub value_type: ValueType,
     pub value: Vec<u8>,
 }
@@ -21,14 +21,14 @@ impl FieldValue {
                   } })
     }
 
-    pub fn field_id(&self) -> FieldID {
+    pub fn field_id(&self) -> FieldId {
         self.field_id
     }
 }
 
 #[derive(Debug)]
 pub struct InMemPoint {
-    pub series_id: SeriesID,
+    pub series_id: SeriesId,
     pub timestamp: Timestamp,
     pub fields: Vec<FieldValue>,
 }
@@ -48,7 +48,7 @@ impl InMemPoint {
         Ok(Self { series_id: 0, timestamp: point.timestamp(), fields })
     }
 
-    pub fn series_id(&self) -> SeriesID {
+    pub fn series_id(&self) -> SeriesId {
         self.series_id
     }
 

--- a/models/src/series_info.rs
+++ b/models/src/series_info.rs
@@ -4,12 +4,12 @@ use utils::BkdrHasher;
 
 use crate::{
     errors::{Error, Result},
-    tag, FieldID, FieldInfo, FieldName, SeriesID, Tag,
+    tag, FieldId, FieldInfo, FieldName, SeriesId, Tag,
 };
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct SeriesInfo {
-    id: SeriesID,
+    id: SeriesId,
     tags: Vec<Tag>,
     field_infos: Vec<FieldInfo>,
 
@@ -65,7 +65,7 @@ impl SeriesInfo {
         }
     }
 
-    pub fn series_id(&self) -> SeriesID {
+    pub fn series_id(&self) -> SeriesId {
         self.id
     }
 
@@ -81,7 +81,7 @@ impl SeriesInfo {
         self.field_infos.push(field_info)
     }
 
-    pub fn field_info_with_id(&self, field_id: FieldID) -> Vec<&FieldInfo> {
+    pub fn field_info_with_id(&self, field_id: FieldId) -> Vec<&FieldInfo> {
         self.field_infos.iter().filter(|f| f.field_id().cmp(&field_id).is_eq()).collect()
     }
 
@@ -98,7 +98,7 @@ impl SeriesInfo {
     }
 }
 
-pub fn generate_series_id(tags: &[Tag]) -> SeriesID {
+pub fn generate_series_id(tags: &[Tag]) -> SeriesId {
     let mut hasher = BkdrHasher::new();
     for tag in tags {
         hasher.hash_with(&tag.key);

--- a/tskv/src/compaction/flush.rs
+++ b/tskv/src/compaction/flush.rs
@@ -1,6 +1,6 @@
 use std::{cmp::max, collections::HashMap, path::PathBuf, sync::Arc};
 
-use models::FieldID;
+use models::FieldId;
 use parking_lot::Mutex;
 use regex::internal::Input;
 use tokio::sync::RwLock;
@@ -100,7 +100,7 @@ impl FlushTask {
     }
 }
 
-fn build_tsm_file(fname: PathBuf, block_set: HashMap<FieldID, DataBlock>) -> Result<u64> {
+fn build_tsm_file(fname: PathBuf, block_set: HashMap<FieldId, DataBlock>) -> Result<u64> {
     let file = file_manager::get_file_manager().create_file(fname).unwrap();
     let mut fs_cursor = file.into_cursor();
 

--- a/tskv/src/forward_index/forward_index.rs
+++ b/tskv/src/forward_index/forward_index.rs
@@ -4,7 +4,7 @@ use std::{
     sync::Arc,
 };
 
-use models::{FieldID, FieldInfo, SeriesID, SeriesInfo, ValueType};
+use models::{FieldId, FieldInfo, SeriesId, SeriesInfo, ValueType};
 use num_traits::ToPrimitive;
 
 use super::*;
@@ -13,7 +13,7 @@ use crate::record_file::{self, Record, RecordFileError, RecordFileResult};
 const VERSION: u8 = 1;
 
 struct InMemSeriesInfo {
-    id: SeriesID,
+    id: SeriesId,
     pos: usize,
     field_infos: Vec<InMemFieldInfo>,
 }
@@ -27,7 +27,7 @@ impl InMemSeriesInfo {
 }
 
 struct InMemFieldInfo {
-    id: FieldID,
+    id: FieldId,
     value_type: ValueType,
 }
 
@@ -38,7 +38,7 @@ impl From<&FieldInfo> for InMemFieldInfo {
 }
 
 pub struct ForwardIndex {
-    series_info_set: HashMap<models::SeriesID, InMemSeriesInfo>,
+    series_info_set: HashMap<models::SeriesId, InMemSeriesInfo>,
     record_writer: record_file::Writer,
     record_reader: record_file::Reader,
     file_path: PathBuf,
@@ -158,11 +158,11 @@ impl ForwardIndex {
             .map_err(|err| ForwardIndexError::CloseFile { source: err })
     }
 
-    pub fn get_series_info_list(&self, sids: &[SeriesID]) -> Vec<SeriesInfo> {
+    pub fn get_series_info_list(&self, sids: &[SeriesId]) -> Vec<SeriesInfo> {
         todo!()
     }
 
-    pub async fn del_series_info(&mut self, series_id: SeriesID) -> ForwardIndexResult<()> {
+    pub async fn del_series_info(&mut self, series_id: SeriesId) -> ForwardIndexResult<()> {
         match self.series_info_set.entry(series_id) {
             std::collections::hash_map::Entry::Occupied(entry) => {
                 self.record_writer

--- a/tskv/src/kvcore.rs
+++ b/tskv/src/kvcore.rs
@@ -5,7 +5,7 @@ use std::{
 
 use ::models::{FieldInfo, InMemPoint, SeriesInfo, Tag, ValueType};
 use logger::{debug, info, init, trace, warn};
-use models::{FieldID, SeriesID, Timestamp};
+use models::{FieldId, SeriesId, Timestamp};
 use once_cell::sync::OnceCell;
 use parking_lot::Mutex;
 use protos::{
@@ -159,7 +159,7 @@ impl TsKv {
         Ok(WritePointsRpcResponse { version: 1, points: vec![] })
     }
 
-    pub async fn read_point(&self, sid: SeriesID, time_range: &TimeRange, field_id: FieldID) {
+    pub async fn read_point(&self, sid: SeriesId, time_range: &TimeRange, field_id: FieldId) {
         let mut version_set = self.version_set.write().await;
         if let Some(tsf) = version_set.get_tsfamily(sid) {
             // get data from memcache
@@ -186,7 +186,7 @@ impl TsKv {
         }
     }
 
-    pub async fn read(&self, sids: Vec<SeriesID>, time_range: &TimeRange, fields: Vec<FieldID>) {
+    pub async fn read(&self, sids: Vec<SeriesId>, time_range: &TimeRange, fields: Vec<FieldId>) {
         for sid in sids {
             for field_id in fields.iter() {
                 self.read_point(sid, time_range, *field_id).await;
@@ -195,7 +195,7 @@ impl TsKv {
     }
 
     pub async fn delete_series(&self,
-                               sids: Vec<SeriesID>,
+                               sids: Vec<SeriesId>,
                                min: Timestamp,
                                max: Timestamp)
                                -> Result<()> {
@@ -210,7 +210,7 @@ impl TsKv {
                     if level.ts_range.overlaps(&timerange) {
                         for column_file in level.files.iter() {
                             if column_file.range().overlaps(&timerange) {
-                                let field_ids: Vec<FieldID> = series_info.field_infos()
+                                let field_ids: Vec<FieldId> = series_info.field_infos()
                                                                          .iter()
                                                                          .map(|f| f.field_id())
                                                                          .collect();

--- a/tskv/src/lru_cache.rs
+++ b/tskv/src/lru_cache.rs
@@ -133,7 +133,7 @@ impl<T> LRUList<T> {
 }
 
 pub type CacheKey = [u8; 16];
-pub type CacheID = u64;
+pub type CacheId = u64;
 type CacheEntry<T> = (T, LRUHandle<CacheKey>);
 
 /// Implementation of `ShardedLRUCache`.
@@ -156,7 +156,7 @@ impl<T> Cache<T> {
 
     /// Returns an ID that is unique for this cache and that can be used to partition the cache
     /// among several users.
-    pub fn new_cache_id(&mut self) -> CacheID {
+    pub fn new_cache_id(&mut self) -> CacheId {
         self.id += 1;
         self.id
     }

--- a/tskv/src/memcache.rs
+++ b/tskv/src/memcache.rs
@@ -3,7 +3,7 @@ use std::{borrow::BorrowMut, collections::HashMap, mem::size_of_val, rc::Rc};
 use flatbuffers::Push;
 use futures::future::ok;
 use logger::{info, warn};
-use models::{FieldID, Timestamp, ValueType};
+use models::{FieldId, Timestamp, ValueType};
 use protos::models::FieldType;
 
 use crate::{byte_utils, error::Result, tseries_family::TimeRange};
@@ -82,7 +82,7 @@ pub struct MemCache {
     max_buf_size: u64,
     // block <field_id, buffer>
     // field_id contain the field type
-    pub data_cache: HashMap<FieldID, MemEntry>,
+    pub data_cache: HashMap<FieldId, MemEntry>,
     // current size
     cache_size: u64,
 }
@@ -100,7 +100,7 @@ impl MemCache {
 
     pub fn insert_raw(&mut self,
                       seq: u64,
-                      field_id: FieldID,
+                      field_id: FieldId,
                       ts: Timestamp,
                       field_type: ValueType,
                       buf: &[u8])
@@ -137,7 +137,7 @@ impl MemCache {
         Ok(())
     }
 
-    pub fn insert(&mut self, field_id: FieldID, val: DataType, value_type: ValueType) {
+    pub fn insert(&mut self, field_id: FieldId, val: DataType, value_type: ValueType) {
         let ts = val.timestamp();
         let item = self.data_cache.entry(field_id).or_insert_with(MemEntry::default);
         if item.ts_max < ts {

--- a/tskv/src/tseries_family.rs
+++ b/tskv/src/tseries_family.rs
@@ -13,7 +13,7 @@ use std::{
 use crossbeam::channel::internal::SelectHandle;
 use datafusion::logical_expr::BuiltinScalarFunction::Random;
 use lazy_static::lazy_static;
-use models::{FieldID, ValueType};
+use models::{FieldId, ValueType};
 use parking_lot::Mutex;
 use tokio::sync::{mpsc::UnboundedSender, RwLock};
 use utils::BloomFilter;
@@ -92,7 +92,7 @@ impl ColumnFile {
         self.being_compact.load(Ordering::Acquire)
     }
 
-    pub fn contains_field_id(&self, field_id: FieldID) -> bool {
+    pub fn contains_field_id(&self, field_id: FieldId) -> bool {
         self.field_id_bloom_filter.contains(&field_id.to_be_bytes())
     }
 }
@@ -130,7 +130,7 @@ impl LevelInfo {
             self.ts_range.min_ts = delta.ts_min;
         }
     }
-    pub fn read_columnfile(&self, tf_id: u32, field_id: FieldID, time_range: &TimeRange) {
+    pub fn read_columnfile(&self, tf_id: u32, field_id: FieldId, time_range: &TimeRange) {
         for file in self.files.iter() {
             let (mut fs_cursor, len) = file.file_reader(tf_id);
             let index = TsmIndexReader::try_new(&mut fs_cursor, len as usize);

--- a/tskv/src/tsm/index.rs
+++ b/tskv/src/tsm/index.rs
@@ -1,4 +1,4 @@
-use models::{FieldID, SeriesID, ValueType};
+use models::{FieldId, SeriesId, ValueType};
 
 use crate::{byte_utils::decode_be_u64, error::Result, tsm::FileBlock, Error};
 
@@ -29,7 +29,7 @@ pub struct Footer {
 }
 
 impl IndexEntry {
-    pub fn field_id(&self) -> FieldID {
+    pub fn field_id(&self) -> FieldId {
         decode_be_u64(&self.key[..8])
     }
 }

--- a/tskv/src/tsm/reader.rs
+++ b/tskv/src/tsm/reader.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use integer_encoding::VarInt;
-use models::{FieldID, ValueType};
+use models::{FieldId, ValueType};
 
 use super::{coders, BLOOM_FILTER_SIZE, FOOTER_SIZE, MAX_BLOCK_VALUES};
 use crate::{
@@ -267,7 +267,7 @@ impl<'a> Iterator for TsmIndexReader<'a> {
 mod test {
     use std::collections::HashMap;
 
-    use models::FieldID;
+    use models::FieldId;
 
     use crate::{
         file_manager::FileManager,
@@ -282,7 +282,7 @@ mod test {
         let mut fs_cursor = fs.into_cursor();
         let index = TsmIndexReader::try_new(&mut fs_cursor, len as usize).unwrap();
         let mut blocks = Vec::new();
-        let mut block_field_id: Vec<FieldID> = Vec::new();
+        let mut block_field_id: Vec<FieldId> = Vec::new();
         for res in index {
             let entry = res.unwrap();
             let key = entry.field_id();
@@ -292,7 +292,7 @@ mod test {
         }
 
         let mut block_reader = TsmBlockReader::new(&mut fs_cursor);
-        let ori_data: HashMap<FieldID, DataBlock> =
+        let ori_data: HashMap<FieldId, DataBlock> =
             HashMap::from([(0,
                             DataBlock::U64 { index: 0,
                                              ts: vec![2, 3, 4],

--- a/tskv/src/tsm/tombstone.rs
+++ b/tskv/src/tsm/tombstone.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use bytes::buf;
-use models::{FieldID, SeriesID, Timestamp, ValueType};
+use models::{FieldId, SeriesId, Timestamp, ValueType};
 use parking_lot::{Mutex, RwLock};
 use snafu::ResultExt;
 
@@ -25,7 +25,7 @@ const TOMBSTONE_MAGIC: u32 = 0x544F4D42;
 
 #[derive(Debug, Clone, Copy)]
 pub struct Tombstone {
-    pub field_id: FieldID,
+    pub field_id: FieldId,
     pub min_ts: Timestamp,
     pub max_ts: Timestamp,
 }
@@ -118,7 +118,7 @@ impl TsmTombstone {
         Ok(())
     }
 
-    pub fn add_range(&self, field_ids: &[FieldID], min: Timestamp, max: Timestamp) -> Result<()> {
+    pub fn add_range(&self, field_ids: &[FieldId], min: Timestamp, max: Timestamp) -> Result<()> {
         let mut file_cursor = self.file_cursor.lock();
         for field_id in field_ids.iter() {
             Self::write_to(&mut file_cursor,

--- a/tskv/src/tsm/writer.rs
+++ b/tskv/src/tsm/writer.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use datafusion::arrow::csv::writer;
-use models::FieldID;
+use models::FieldId;
 use snafu::ResultExt;
 use utils::{BkdrHasher, BloomFilter};
 
@@ -116,7 +116,7 @@ pub struct TsmIndexWriter {}
 
 impl TsmIndexWriter {
     pub fn write_to(writer: &mut FileCursor,
-                    indexs: HashMap<FieldID, Vec<FileBlock>>)
+                    indexs: HashMap<FieldId, Vec<FileBlock>>)
                     -> Result<BloomFilter> {
         let mut bloom_filter = new_bloom_filter();
         for (fid, blks) in indexs {
@@ -147,8 +147,8 @@ pub struct TsmBlockWriter {}
 
 impl TsmBlockWriter {
     pub(crate) fn write_to(writer: &mut FileCursor,
-                           mut block_set: HashMap<FieldID, DataBlock>)
-                           -> Result<HashMap<FieldID, Vec<FileBlock>>> {
+                           mut block_set: HashMap<FieldId, DataBlock>)
+                           -> Result<HashMap<FieldId, Vec<FileBlock>>> {
         let mut res = HashMap::new();
         for (fid, block) in block_set.iter_mut() {
             let index = Self::write_one_to(writer, block)?;
@@ -198,7 +198,7 @@ impl TsmBlockWriter {
 mod test {
     use std::collections::HashMap;
 
-    use models::FieldID;
+    use models::FieldId;
 
     use crate::{
         direct_io::FileSync,
@@ -231,10 +231,10 @@ mod test {
         let data = vec![DataBlock::U64 { index: 0, ts: vec![2, 3, 4], val: vec![12, 13, 15] },
                         DataBlock::U64 { index: 0, ts: vec![2, 3, 4], val: vec![101, 102, 103] }];
 
-        let mut file_block_map: HashMap<FieldID, Vec<FileBlock>> = HashMap::new();
+        let mut file_block_map: HashMap<FieldId, Vec<FileBlock>> = HashMap::new();
         for (k, v) in data.iter().enumerate() {
             let file_blocks = TsmBlockWriter::write_one_to(&mut fs_cursor, v).unwrap();
-            file_block_map.insert(k as FieldID, file_blocks);
+            file_block_map.insert(k as FieldId, file_blocks);
         }
 
         let index_pos = fs_cursor.pos();


### PR DESCRIPTION
Just some refactoring: Rename some words in crate `models` and `tskv`